### PR TITLE
add controllers topic

### DIFF
--- a/ProsthesisEmulator/src/main/kotlin/emulator/ControllerEmulator.kt
+++ b/ProsthesisEmulator/src/main/kotlin/emulator/ControllerEmulator.kt
@@ -4,6 +4,7 @@ import emulator.models.MqttDataModel
 import io.reactivex.rxjava3.kotlin.subscribeBy
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import kotlin.concurrent.timer
 
 /**
  * Эмулятор бионического протеза руки. Поддерживает протокол протеза и выполняет отправку данных, эмулирующих протез.
@@ -30,7 +31,6 @@ class ControllerEmulator {
         // Подписка на состояние подключения
         client.getIsConnectedObservable().subscribeBy(onNext = {
             isConnected = true
-            client.sendData("controllers", "Test message")
         }, onError = {
             logger.error(it.message)
         }, onComplete = {


### PR DESCRIPTION
Добавлен топик `controllers/online` и `controllers/offline`. При подключении к серверу эмулятора каждые 15 секунд в топик online начинает отправляться id эмулятора, по которому можно определить, что эмулятор подключен. Оповещение об отключении реализовано за счет MQTT механизма LWT ([Last Will Testament](https://stackoverflow.com/questions/17270863/mqtt-what-is-the-purpose-or-usage-of-last-will-testament)). При обрыве или отключении эмулятора MQTT сервер сам отправит сообщение с id эмулятора на offline топик. 
Пример: 
![image](https://user-images.githubusercontent.com/38138387/93396979-4a586c80-f881-11ea-9ce1-166769383127.png)
