### PR TITLE
Implement telemetry streaming

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <kotlin.version>1.4.10</kotlin.version>
         <serialization.version>1.0.0-RC</serialization.version>
+        <grpc.kotlin.version>1.0.0</grpc.kotlin.version>
         <spring.version>2.3.4.RELEASE</spring.version>
         <spring.security.version>5.3.4.RELEASE</spring.security.version>
         <vertx.version>3.9.4</vertx.version>
@@ -135,6 +136,11 @@
             <artifactId>grpc-stub</artifactId>
             <version>1.33.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-kotlin-stub</artifactId>
+            <version>${grpc.kotlin.version}</version>
+        </dependency>
 
         <!-- Logging -->
         <dependency>
@@ -170,6 +176,13 @@
             <artifactId>jedis</artifactId>
             <version>3.3.0</version>
             <type>jar</type>
+        </dependency>
+
+        <!-- Coroutines -->
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+            <version>1.3.9</version>
         </dependency>
     </dependencies>
 
@@ -247,6 +260,16 @@
                     <protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.32.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <protocPlugins>
+                        <protocPlugin>
+                            <id>grpc-kotlin</id>
+                            <groupId>io.grpc</groupId>
+                            <artifactId>protoc-gen-grpc-kotlin</artifactId>
+                            <version>${grpc.kotlin.version}</version>
+                            <classifier>jdk7</classifier>
+                            <mainClass>io.grpc.kotlin.generator.GeneratorRunner</mainClass>
+                        </protocPlugin>
+                    </protocPlugins>
                 </configuration>
                 <executions>
                     <execution>

--- a/server/src/main/kotlin/com/handcontrol/server/grpc/TelemetryStreamImpl.kt
+++ b/server/src/main/kotlin/com/handcontrol/server/grpc/TelemetryStreamImpl.kt
@@ -1,0 +1,40 @@
+package com.handcontrol.server.grpc
+
+import com.handcontrol.server.mqtt.command.dto.TelemetryDto
+import com.handcontrol.server.mqtt.command.get.GetTelemetry
+import com.handcontrol.server.protobuf.Stream
+import com.handcontrol.server.protobuf.TelemetryStreamGrpcKt
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.ExperimentalSerializationApi
+import org.lognet.springboot.grpc.GRpcService
+import org.springframework.beans.factory.annotation.Autowired
+
+@GRpcService
+@ExperimentalCoroutinesApi
+@ExperimentalSerializationApi
+class TelemetryStreamImpl : TelemetryStreamGrpcKt.TelemetryStreamCoroutineImplBase() {
+
+    @Autowired
+    private lateinit var getTelemetry: GetTelemetry
+
+    @FlowPreview
+    override fun startTelemetryStream(request: Stream.SubRequest): Flow<Stream.PubReply> {
+        val id = request.id
+        getTelemetry.subscribe(id)
+        val channel = getTelemetry.getChannel(id)
+
+        return flow {
+            while (true) {
+                val receive = channel.receive()
+
+                val buildTelemetry = Stream.PubReply.newBuilder()
+                    .setTelemetry(TelemetryDto.createFrom(receive))
+                    .build()
+                emit(buildTelemetry)
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/com/handcontrol/server/mqtt/command/dto/TelemetryDto.kt
+++ b/server/src/main/kotlin/com/handcontrol/server/mqtt/command/dto/TelemetryDto.kt
@@ -1,8 +1,8 @@
 package com.handcontrol.server.mqtt.command.dto
 
-import com.handcontrol.server.protobuf.Enums
 import com.handcontrol.server.protobuf.Enums.DriverStatusType
 import com.handcontrol.server.protobuf.Enums.ModuleStatusType
+import com.handcontrol.server.protobuf.TelemetryOuterClass
 import kotlinx.serialization.Serializable
 
 /**
@@ -10,18 +10,39 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class TelemetryDto(
-        val telemetryFrequency: Int = 0,
-        val emgStatus: ModuleStatusType = ModuleStatusType.MODULE_STATUS_INITIALIZATION,
-        val displayStatus: ModuleStatusType = ModuleStatusType.MODULE_STATUS_INITIALIZATION,
-        val gyroStatus: ModuleStatusType = ModuleStatusType.MODULE_STATUS_INITIALIZATION,
-        val driverStatus: DriverStatusType = DriverStatusType.DRIVER_STATUS_INITIALIZATION,
-        val lastTimeSync: Long = 0,
-        val emg: Int = 0,
-        val executableGesture: UuidDto = UuidDto(""),
-        val power: Int = 0,
-        val pointerFingerPosition: Int = 0,
-        val middleFingerPosition: Int = 0,
-        val ringFinderPosition: Int = 0,
-        val littleFingerPosition: Int = 0,
-        val thumbFingerPosition: Int = 0
-)
+    val telemetryFrequency: Int = 0,
+    val emgStatus: ModuleStatusType = ModuleStatusType.MODULE_STATUS_INITIALIZATION,
+    val displayStatus: ModuleStatusType = ModuleStatusType.MODULE_STATUS_INITIALIZATION,
+    val gyroStatus: ModuleStatusType = ModuleStatusType.MODULE_STATUS_INITIALIZATION,
+    val driverStatus: DriverStatusType = DriverStatusType.DRIVER_STATUS_INITIALIZATION,
+    val lastTimeSync: Long = 0,
+    val emg: Int = 0,
+    val executableGesture: UuidDto = UuidDto(""),
+    val power: Int = 0,
+    val pointerFingerPosition: Int = 0,
+    val middleFingerPosition: Int = 0,
+    val ringFinderPosition: Int = 0,
+    val littleFingerPosition: Int = 0,
+    val thumbFingerPosition: Int = 0
+) {
+    companion object {
+        fun createFrom(from: TelemetryDto): TelemetryOuterClass.Telemetry {
+            return TelemetryOuterClass.Telemetry.newBuilder()
+                .setTelemetryFrequency(from.telemetryFrequency)
+                .setEmgStatus(from.emgStatus)
+                .setDisplayStatus(from.displayStatus)
+                .setGyroStatus(from.gyroStatus)
+                .setDriverStatus(from.driverStatus)
+                .setLastTimeSync(from.lastTimeSync)
+                .setEmg(from.emg)
+                .setExecutableGesture(UuidDto.createFrom(from.executableGesture))
+                .setPower(from.power)
+                .setPointerFingerPosition(from.pointerFingerPosition)
+                .setMiddleFingerPosition(from.middleFingerPosition)
+                .setRingFingerPosition(from.ringFinderPosition)
+                .setLittleFingerPosition(from.littleFingerPosition)
+                .setThumbFingerPosition(from.thumbFingerPosition)
+                .build()
+        }
+    }
+}

--- a/server/src/main/kotlin/com/handcontrol/server/mqtt/command/get/GetTelemetry.kt
+++ b/server/src/main/kotlin/com/handcontrol/server/mqtt/command/get/GetTelemetry.kt
@@ -4,6 +4,11 @@ import com.handcontrol.server.mqtt.command.DynamicCommand
 import com.handcontrol.server.mqtt.command.dto.TelemetryDto
 import com.handcontrol.server.mqtt.command.enums.DynamicApi.DynamicTopic.GET_TELEMETRY
 import com.handcontrol.server.util.ProtobufSerializer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -13,14 +18,34 @@ import org.springframework.stereotype.Component
  *  Updates every second
  */
 @Component
+@ExperimentalCoroutinesApi
 @ExperimentalSerializationApi
 class GetTelemetry : DynamicCommand(GET_TELEMETRY) {
     private val logger = LoggerFactory.getLogger(GetTelemetry::class.java)
 
+    private val subscribers = mutableMapOf<String, Channel<TelemetryDto>>()
+
     override fun handlePayloadAndId(id: String, byteArray: ByteArray) {
         val telemetry = ProtobufSerializer.deserialize<TelemetryDto>(byteArray)
         logger.debug("Get telemetry from {}: {}", id, telemetry)
-        // todo save it?
+
+        val sub = subscribers[id]
+        if (sub == null) {
+            logger.debug("No subscribers for telemetry from id: {}", id)
+            return
+        }
+
+        runBlocking {
+            sub.send(telemetry)
+        }
     }
 
+    fun subscribe(id: String) {
+        subscribers[id] = Channel(CONFLATED)
+    }
+
+    @FlowPreview
+    fun getChannel(id: String): Channel<TelemetryDto> {
+        return subscribers[id]!!
+    }
 }

--- a/server/src/main/proto/com/handcontrol/server/protobuf/stream.proto
+++ b/server/src/main/proto/com/handcontrol/server/protobuf/stream.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+package com.handcontrol.server.protobuf;
+
+import "com/handcontrol/server/protobuf/telemetry.proto";
+
+service TelemetryStream {
+  rpc StartTelemetryStream (SubRequest) returns (stream PubReply);
+}
+
+message SubRequest {
+  string id = 1;
+}
+
+message PubReply {
+  Telemetry telemetry = 1;
+}

--- a/server/src/main/proto/com/handcontrol/server/protobuf/telemetry.proto
+++ b/server/src/main/proto/com/handcontrol/server/protobuf/telemetry.proto
@@ -1,5 +1,6 @@
 syntax="proto3";
 package com.handcontrol.server.protobuf;
+
 import "com/handcontrol/server/protobuf/enums.proto";
 import "com/handcontrol/server/protobuf/uuid.proto";
 

--- a/server/src/main/resources/application-dev.yaml
+++ b/server/src/main/resources/application-dev.yaml
@@ -1,3 +1,9 @@
+logging:
+  level:
+    com:
+      handcontrol:
+        server: debug
+
 mqtt:
   broker-addr: 92.53.124.175
 


### PR DESCRIPTION
The idea:
- client subscribes to the telemetry of the prosthesis by calling method startTelemetryStreaming(prosthesisId)
- server add id to the subscribers map and create a channel for it
- channel is conflated - every new element erases previous
- telemetry is got from the channel, converted and passed to client as flow element

Not implemented:
- remove subscription if client closes a connection